### PR TITLE
chore: QueryDSL 설정 및 Q클래스 생성 경로 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,34 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // === queryDSL 의존성 설정 (Spring Boot 3.x) 시작 ===
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta' // 메인 라이브러리
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta' // Q클래스를 생성
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0' // Q클래스 생성 시 필요한 어노테이션(@Entity, @Id, @Column 등) 정의 제공
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api:2.1.1' // Jakarta 어노테이션 지원
+    // === queryDSL 의존성 설정 (Spring Boot 3.x) 종료 ===
 }
+
+// === queryDSL 설정 시작 (Gradle 8.x) ===
+// Q클래스가 생성될 경로
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+// Q클래스가 해당 디렉토리에 생성되도록 지정
+tasks.withType(JavaCompile).configureEach {
+    options.generatedSourceOutputDirectory.set(querydslDir)
+}
+
+// Q클래스 디렉토리를 Java 소스 경로로 추가
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+// clean 시 Q클래스 삭제
+clean.doLast {
+    file(querydslDir).deleteDir()
+}
+// === queryDSL 설정 종료 ===
 
 tasks.named('test') {
     useJUnitPlatform()


### PR DESCRIPTION
[설명]
- querydsl-jpa, querydsl-apt 등 의존성 추가
- Q타입 생성 경로 설정
- Gradle 8 최신 방식 적용 (generatedSourceOutputDirectory)

[빌드방법]
- gradle 아이콘을 눌러 의존성 추가
- 애플리케이션 실행하여 Q클래스 생성
- Q클래스 객체 생성 코드 작성 시 자동완성 기능 활성화되면 성공