### PR TITLE
impl(schedule): 일정 전체 조회 시 댓글 개수 함께 응답

### DIFF
--- a/src/main/java/com/example/schedulemanagementdevelopapi/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedulemanagementdevelopapi/schedule/controller/ScheduleController.java
@@ -39,11 +39,11 @@ public class ScheduleController {
     }
 
     @GetMapping
-    public ResponseEntity<List<ScheduleSearchSummaryResponseDto>> search(
+    public ResponseEntity<List<ScheduleSearchSummaryResponseDto>> searchWithCommentCount(
             @ModelAttribute ScheduleSearchConditionDto cond
     ) {
 
-        return ResponseEntity.ok(scheduleService.search(cond));
+        return ResponseEntity.ok(scheduleService.searchWithCommentCount(cond));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/example/schedulemanagementdevelopapi/schedule/dto/response/ScheduleSearchSummaryResponseDto.java
+++ b/src/main/java/com/example/schedulemanagementdevelopapi/schedule/dto/response/ScheduleSearchSummaryResponseDto.java
@@ -9,16 +9,18 @@ public record ScheduleSearchSummaryResponseDto(
         String writer,
         String title,
         String content,
+        long commentCount,
         LocalDateTime createdAt,
         LocalDateTime modifiedAt
 ) {
 
-    public static ScheduleSearchSummaryResponseDto from(Schedule schedule) {
+    public static ScheduleSearchSummaryResponseDto from(Schedule schedule, long commentCount) {
         return new ScheduleSearchSummaryResponseDto(
                 schedule.getId(),
                 schedule.getMember().getName(),
                 schedule.getTitle(),
                 schedule.getContent(),
+                commentCount,
                 schedule.getCreatedAt(),
                 schedule.getModifiedAt()
         );

--- a/src/main/java/com/example/schedulemanagementdevelopapi/schedule/repository/ScheduleRepositoryCustom.java
+++ b/src/main/java/com/example/schedulemanagementdevelopapi/schedule/repository/ScheduleRepositoryCustom.java
@@ -1,11 +1,11 @@
 package com.example.schedulemanagementdevelopapi.schedule.repository;
 
 import com.example.schedulemanagementdevelopapi.schedule.dto.request.ScheduleSearchConditionDto;
-import com.example.schedulemanagementdevelopapi.schedule.entity.Schedule;
+import com.example.schedulemanagementdevelopapi.schedule.dto.response.ScheduleSearchSummaryResponseDto;
 
 import java.util.List;
 
 public interface ScheduleRepositoryCustom {
 
-    List<Schedule> search(ScheduleSearchConditionDto cond);
+    List<ScheduleSearchSummaryResponseDto> searchWithCommentCount(ScheduleSearchConditionDto cond);
 }

--- a/src/main/java/com/example/schedulemanagementdevelopapi/schedule/repository/ScheduleRepositoryImpl.java
+++ b/src/main/java/com/example/schedulemanagementdevelopapi/schedule/repository/ScheduleRepositoryImpl.java
@@ -1,9 +1,13 @@
 package com.example.schedulemanagementdevelopapi.schedule.repository;
 
+import com.example.schedulemanagementdevelopapi.comment.entity.QComment;
+import com.example.schedulemanagementdevelopapi.member.entity.QMember;
 import com.example.schedulemanagementdevelopapi.schedule.dto.request.ScheduleSearchConditionDto;
+import com.example.schedulemanagementdevelopapi.schedule.dto.response.ScheduleSearchSummaryResponseDto;
 import com.example.schedulemanagementdevelopapi.schedule.entity.QSchedule;
-import com.example.schedulemanagementdevelopapi.schedule.entity.Schedule;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.util.StringUtils;
@@ -14,22 +18,43 @@ import java.util.List;
 public class ScheduleRepositoryImpl implements ScheduleRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
-    private final QSchedule qSchedule = QSchedule.schedule;
 
     @Override
-    public List<Schedule> search(ScheduleSearchConditionDto cond) {
+    public List<ScheduleSearchSummaryResponseDto> searchWithCommentCount(ScheduleSearchConditionDto cond) {
+        QSchedule qSchedule = QSchedule.schedule;
+        QComment qComment = QComment.comment;
+        QMember qMember = QMember.member;
 
         return queryFactory
-                .selectFrom(qSchedule)
+                .select(
+                        Projections.constructor(ScheduleSearchSummaryResponseDto.class,
+                        qSchedule.id,
+                        qMember.name,
+                        qSchedule.title,
+                        qSchedule.content,
+                        JPAExpressions
+                                .select(qComment.id.count())
+                                .from(qComment)
+                                .where(
+                                        qComment.schedule.id.eq(qSchedule.id),
+                                        qComment.deletedAt.isNull()
+                                ),
+                        qSchedule.createdAt,
+                        qSchedule.modifiedAt
+                ))
+                .from(qSchedule)
+                .leftJoin(qSchedule.member, qMember)
                 .where(
+                        qSchedule.deletedAt.isNull(),
                         containsTitle(cond.getTitle())
                 )
-                .where(qSchedule.deletedAt.isNull())
                 .orderBy(qSchedule.modifiedAt.desc())
                 .fetch();
     }
 
     private BooleanExpression containsTitle(String title) {
+        QSchedule qSchedule = QSchedule.schedule;
+
         return (StringUtils.hasText(title))
                 ? qSchedule.title.contains(title)
                 : null;

--- a/src/main/java/com/example/schedulemanagementdevelopapi/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/schedulemanagementdevelopapi/schedule/service/ScheduleService.java
@@ -13,7 +13,7 @@ public interface ScheduleService {
 
     ScheduleSaveResponseDto save(Long memberId, String title, String content);
 
-    List<ScheduleSearchSummaryResponseDto> search(ScheduleSearchConditionDto cond);
+    List<ScheduleSearchSummaryResponseDto> searchWithCommentCount(ScheduleSearchConditionDto cond);
 
     ScheduleSearchDetailResponseDto findById(Long id);
 

--- a/src/main/java/com/example/schedulemanagementdevelopapi/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/schedulemanagementdevelopapi/schedule/service/ScheduleServiceImpl.java
@@ -41,12 +41,9 @@ public class ScheduleServiceImpl implements ScheduleService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<ScheduleSearchSummaryResponseDto> search(ScheduleSearchConditionDto cond) {
+    public List<ScheduleSearchSummaryResponseDto> searchWithCommentCount(ScheduleSearchConditionDto cond) {
 
-        return scheduleRepository.search(cond)
-                .stream()
-                .map(ScheduleSearchSummaryResponseDto::from)
-                .toList();
+        return scheduleRepository.searchWithCommentCount(cond);
     }
 
     @Override


### PR DESCRIPTION
- DTO 프로젝션을 활용해 순수 Entity 유지하고, DTO로 매핑하여 반환
- 서브쿼리를 사용하여 댓글 개수 count
- Left Join 활용하여 작성자명을 가져오도록 수정

closes #66 