### PR TITLE
fix(all): 수정 시 응답데이터의 수정일이 반영이 되지 않는 오류 수정

### DIFF
--- a/src/main/java/com/example/schedulemanagementdevelopapi/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/example/schedulemanagementdevelopapi/comment/service/CommentServiceImpl.java
@@ -46,6 +46,8 @@ public class CommentServiceImpl implements CommentService {
 
         findComment.updateContent(content);
 
+        commentRepository.saveAndFlush(findComment);
+
         return CommentUpdateResponseDto.from(findComment);
     }
 

--- a/src/main/java/com/example/schedulemanagementdevelopapi/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/example/schedulemanagementdevelopapi/member/service/MemberServiceImpl.java
@@ -83,6 +83,8 @@ public class MemberServiceImpl implements MemberService {
         findMember.updateName(requestDto.getName());
         findMember.updateEmail(requestDto.getEmail());
 
+        memberRepository.saveAndFlush(findMember);
+
         return MemberUpdateResponseDto.from(findMember);
     }
 

--- a/src/main/java/com/example/schedulemanagementdevelopapi/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/schedulemanagementdevelopapi/schedule/service/ScheduleServiceImpl.java
@@ -74,6 +74,8 @@ public class ScheduleServiceImpl implements ScheduleService {
         findSchedule.updateTitle(requestDto.getTitle());
         findSchedule.updateContent(requestDto.getContent());
 
+        scheduleRepository.saveAndFlush(findSchedule);
+
         return ScheduleUpdateResponseDto.from(findSchedule);
     }
 


### PR DESCRIPTION
트랜잭션 안에서 **dirty-checking** 후 flush 되기 전에 DTO로 매핑하여 발생한 문제
즉시 flush 후 매핑하도록 수정

closes #97 